### PR TITLE
Pass :repositories through to eval-in-project

### DIFF
--- a/plugin/src/leiningen/cljsbuild.clj
+++ b/plugin/src/leiningen/cljsbuild.clj
@@ -77,7 +77,8 @@
                              (:extra-classpath-dirs project)
                              (map :source-path option-seq))
      :dependencies (merge-dependencies (:dependencies project))
-     :dev-dependencies (:dev-dependencies project)}
+     :dev-dependencies (:dev-dependencies project)
+     :repositories (:repositories project)}
     form
     nil
     nil


### PR DESCRIPTION
This fixes a subtle bug that will only manifest if your cljsbuild project contains dependencies you've never fetched before.
