### PR TITLE
Exclude ant from dependencies.

### DIFF
--- a/support/project.clj
+++ b/support/project.clj
@@ -5,6 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"
             :distribution :repo}
   :dependencies [[org.clojure/clojure "1.3.0"]
-                 [org.clojure/clojurescript "0.0-971"]
+                 [org.clojure/clojurescript "0.0-971"
+                  :exclusions [org.apache.ant/ant]]
                  [fs "1.1.2"]
                  [clj-stacktrace "0.2.4"]])


### PR DESCRIPTION
Requiring ant as a dev-dependency will occasionally cause problems
with leiningen.
