### PR TITLE
Added :notify-command option

### DIFF
--- a/plugin/src/leiningen/cljsbuild.clj
+++ b/plugin/src/leiningen/cljsbuild.clj
@@ -36,25 +36,26 @@
   ; the files it contains won't be classloadable, for some reason.
   (when (not-empty crossovers)
     (fs/mkdirs crossover-path))
-  (run-local-project project crossover-path builds
-    '(require 'cljsbuild.compiler 'cljsbuild.crossover 'cljsbuild.util)
-    `(do
-      (letfn [(copy-crossovers# []
-                (cljsbuild.crossover/copy-crossovers
-                  ~crossover-path
-                  '~crossovers))]
-        (copy-crossovers#)
-        (when ~watch?
-          (cljsbuild.util/once-every 1000 "copying crossovers" copy-crossovers#))
-        (cljsbuild.util/in-threads
-          (fn [opts#]
-            (cljsbuild.compiler/run-compiler
-              (:source-path opts#)
-              ~crossover-path
-              (:compiler opts#)
-              (:notify-command opts#)
-              ~watch?))
-          '~builds)))))
+  (let [parsed-builds (map #(update-in % [:notify-command] config/parse-shell-command) builds)]
+    (run-local-project project crossover-path parsed-builds
+      '(require 'cljsbuild.compiler 'cljsbuild.crossover 'cljsbuild.util)
+      `(do
+        (letfn [(copy-crossovers# []
+                  (cljsbuild.crossover/copy-crossovers
+                    ~crossover-path
+                    '~crossovers))]
+          (copy-crossovers#)
+          (when ~watch?
+            (cljsbuild.util/once-every 1000 "copying crossovers" copy-crossovers#))
+          (cljsbuild.util/in-threads
+            (fn [opts#]
+              (cljsbuild.compiler/run-compiler
+                (:source-path opts#)
+                ~crossover-path
+                (:compiler opts#)
+                (:notify-command opts#) 
+                ~watch?))
+            '~parsed-builds))))))
 
 (defn- run-tests [project {:keys [test-commands crossover-path builds]} args]
   (when (> (count args) 1)

--- a/plugin/src/leiningen/cljsbuild/config.clj
+++ b/plugin/src/leiningen/cljsbuild/config.clj
@@ -21,6 +21,7 @@
 (def default-build-options
   {:source-path "src-cljs"
    :jar false
+   :notify-command nil
    :compiler default-compiler-options})
 
 (defn- backwards-compat-builds [options]

--- a/support/src/cljsbuild/compiler.clj
+++ b/support/src/cljsbuild/compiler.clj
@@ -25,13 +25,14 @@
     (with-precision 2
       (str (/ (double elapsed-us) 1000000000) " seconds"))))
 
-(defn- notify-cljs [notify-command msg]
+(defn- notify-cljs [cmd msg]
   (try
-    (cond
-      (= :bell notify-command) (print-safe \u0007)
-      (string? notify-command) (.exec (Runtime/getRuntime)
-                                 (format notify-command msg)))
-    (catch Throwable e)) 
+    (if (:bell cmd)
+      (print-safe \u0007)) 
+    (if (first (:shell cmd)) 
+      (util/sh (assoc cmd :shell (map #(if (= % "%") msg %) (:shell cmd))))) 
+    (catch Throwable e
+      (pst+ e))) 
   (println-safe msg))
 
 (defn- compile-cljs [cljs-path compiler-options notify-command]

--- a/support/src/cljsbuild/test.clj
+++ b/support/src/cljsbuild/test.clj
@@ -2,16 +2,12 @@
   (:require
     [cljsbuild.util :as util]))
 
-(defn sh [command]
-  (let [process (util/process-start command)]
-    ((:wait process))))
-
 (defmacro dofor [seq-exprs body-expr]
   `(doall (for ~seq-exprs ~body-expr)))
 
 (defn run-tests [test-commands]
   (let [success (every? #(= % 0)
                   (dofor [test-command test-commands]
-                    (sh test-command)))]
+                    (util/sh test-command)))]
     (when (not success)
       (throw (Exception. "Test failed.")))))

--- a/support/src/cljsbuild/util.clj
+++ b/support/src/cljsbuild/util.clj
@@ -75,3 +75,8 @@ and returns a seq of the results. Launches all the threads at once."
              (.waitFor process)
              (deref pumper)
              (.exitValue process))}))
+
+(defn sh [command]
+  (let [process (process-start command)]
+    ((:wait process))))
+


### PR DESCRIPTION
I took your advice and named the new option `:notify-command`; it is a per-build-profile option and can either be a string or have the value :bell, i.e:

```
:builds [{
  :notify-command :bell
  ...
}
{
  :notify-command "growlnotify -m '%s'"
  ...
}
```

When it is a string it is passed to `core/format` with the compiler success / failure message as an additional argument, so users can use it any way they like.

Let me know if I need to change something for this to go through :)
