### PR TITLE
Hi, I'm pretty sure the foreign-libs example in sample.project.clj is wrong. Here's a correction. :-)

### DIFF
--- a/sample.project.clj
+++ b/sample.project.clj
@@ -104,5 +104,5 @@
           :libs ["closure/library/third_party/closure"]
           ; Adds dependencies on foreign libraries.
           ; Defaults to the empty vector [].
-          :foreign-libs [[{:file "http://example.com/remote.js"
-                           :provides  ["my.example"]}]]}}}})
+          :foreign-libs [{:file "http://example.com/remote.js"
+                           :provides  ["my.example"]}]}}}})


### PR DESCRIPTION
There was an extra vector wrapping the details - it should be [{...}], not [[{...}]].
