### PR TITLE
remove `shutdown-agents` call so later future/agent usage won't fail; fixes gh-136

### DIFF
--- a/plugin/src/leiningen/cljsbuild.clj
+++ b/plugin/src/leiningen/cljsbuild.clj
@@ -47,9 +47,7 @@
 
 (defn- run-local-project [project crossover-path builds requires form]
   (subproject/eval-in-project project crossover-path builds
-    `(do
-      ~form
-      (shutdown-agents))
+    form
     requires)
   (exit-success))
 


### PR DESCRIPTION
remove `shutdown-agents` call so later future/agent usage won't fail; fixes gh-136
