### PR TITLE
println consistent with other compile messages.

### DIFF
--- a/plugin/src/leiningen/cljsbuild.clj
+++ b/plugin/src/leiningen/cljsbuild.clj
@@ -55,7 +55,7 @@
   (doseq [build-id build-ids]
     (if (empty? (filter #(= (:id %) build-id) builds))
       (throw (Exception. (str "Unknown build identifier: " build-id)))))
-  (println "Compiling ClojureScript.")
+  (println "Compiling ClojureScript")
   ; If crossover-path does not exist before eval-in-project is called,
   ; the files it contains won't be classloadable, for some reason.
   (when (not-empty crossovers)


### PR DESCRIPTION
This is so minor it almost doesn't matter, but I see this message many times a day, and it'd be nice to have it consistent with the other build ones:

```
       Performing task 'compile' with profile(s): 'production'
       Compiling redacted.views
       Compiling redacted.routes
       Compiling ClojureScript.
```
