### PR TITLE
Fixed example projects for use with Leiningen 2.x 

### DIFF
--- a/example-projects/advanced/project.clj
+++ b/example-projects/advanced/project.clj
@@ -1,14 +1,11 @@
 (defproject cljsbuild-example-advanced "0.2.9"
   :description "An advanced example of how to use lein-cljsbuild"
-  ; Source path for Leiningen 1.x:
-  :source-path "src-clj"
-  ; Source paths for Leiningen 2.x:
   :source-paths ["src-clj"]
   :dependencies [[org.clojure/clojure "1.4.0"]
                  [compojure "1.0.4"]
                  [hiccup "1.0.0"]]
-  :dev-dependencies [[lein-ring "0.7.0"]]
-  :plugins [[lein-cljsbuild "0.2.9"]]
+  :plugins [[lein-cljsbuild "0.2.9"]
+            [lein-ring "0.7.0"]]
   ; Enable the lein hooks for: clean, compile, test, and jar.
   :hooks [leiningen.cljsbuild]
   :cljsbuild {
@@ -74,4 +71,8 @@
        :compiler {:output-to "resources/private/js/unit-test.js"
                   :optimizations :whitespace
                   :pretty-print true}}}}
-  :ring {:handler example.routes/app})
+  :ring {:handler example.routes/app}
+  ; for Leiningen 1.x:
+  :source-path "src-clj"
+  :dev-dependencies [[lein-ring "0.7.0"]]
+  )

--- a/example-projects/simple/project.clj
+++ b/example-projects/simple/project.clj
@@ -1,17 +1,18 @@
 (defproject cljsbuild-example-simple "0.2.9"
   :description "A simple example of how to use lein-cljsbuild"
-  ; Source path for Leiningen 1.x:
-  :source-path "src-clj"
-  ; Source paths for Leiningen 2.x:
   :source-paths ["src-clj"]
   :dependencies [[org.clojure/clojure "1.4.0"]
                  [compojure "1.0.4"]
                  [hiccup "1.0.0"]]
-  :dev-dependencies [[lein-ring "0.7.0"]]
-  :plugins [[lein-cljsbuild "0.2.9"]]
+  :plugins [[lein-cljsbuild "0.2.9"]
+            [lein-ring "0.7.0"]]
   :cljsbuild {
     :builds [{:source-path "src-cljs"
               :compiler {:output-to "resources/public/js/main.js"
                          :optimizations :whitespace
                          :pretty-print true}}]}
-  :ring {:handler example.routes/app})
+  :ring {:handler example.routes/app}
+  ; for Leiningen 1.x:
+  :source-path "src-clj"
+  :dev-dependencies [[lein-ring "0.7.0"]]
+  )


### PR DESCRIPTION
Since :dev-dependencies is replaced by :profiles we need to include lein-ring as a plugin.
