### PR TITLE
Default compiler tmp output to /tmp/cljsc-out

### DIFF
--- a/plugin/src/leiningen/cljsbuild/config.clj
+++ b/plugin/src/leiningen/cljsbuild/config.clj
@@ -18,6 +18,7 @@
 
 (def default-compiler-options
   {:output-to "main.js"
+   :output-dir "tmp/cljsc-out"
    :optimizations :whitespace
    :warnings true
    :externs []


### PR DESCRIPTION
Assuming https://github.com/emezeske/lein-cljsbuild/issues/165 makes sense
