### PR TITLE
Add support for multiple source paths

### DIFF
--- a/plugin/src/leiningen/cljsbuild.clj
+++ b/plugin/src/leiningen/cljsbuild.clj
@@ -85,7 +85,7 @@
                       (doall
                         (for [[build# mtimes#] builds-mtimes#]
                           (cljsbuild.compiler/run-compiler
-                            (:source-path build#)
+                            (cljsbuild.compiler/get-source-paths build#)
                             ~crossover-path
                             crossover-macro-paths#
                             (:compiler build#)


### PR DESCRIPTION
Adds support for a `:source-paths [path1 path2 ...]` option for a build, overriding the standard `:source-path` attribute.

This works but should probably breaks the tests. I didnt run them cause I'm not familiar with midje and your whole testing setup. Basically the only thing changed is the `cljsbuild.compiler/run-compiler` function in that it expects a seq of paths instead of a single path.

There is one part of that function I did not look into yet, since I didnt fully get what its intention was. See FIXME comment.

It does not require any changes to the clojurescript compiler itself.

Probably resolves #157 and #108
