### PR TITLE
Fix 30 second delay caused by failing tests

### DIFF
--- a/plugin/src/leiningen/cljsbuild.clj
+++ b/plugin/src/leiningen/cljsbuild.clj
@@ -22,7 +22,12 @@
   (leval/eval-in-project (subproject/make-subproject project crossover-path builds)
     ; Without an explicit exit, the in-project subprocess seems to just hang for
     ; around 30 seconds before exiting.  I don't fully understand why...
-    `(~form (System/exit 0))
+    `(try
+       (do ~form
+           (System/exit 0))
+       (catch Exception e#
+         (do (.printStackTrace e#)
+             (System/exit 1))))
     requires))
 
 (defn- run-compiler [project {:keys [crossover-path crossovers builds]} build-ids watch?]


### PR DESCRIPTION
I'm running `mocha-phantomjs` from cljsbuild, and I noticed that when tests fail, the runner hangs for 30 seconds.

The delay seems to come from `run-local-project`, and it's already commented there. However, when exception is thrown by the called code, `System.exit` is not called.

Adding the exception trap prevents the delay.
