### PR TITLE
Most recent version of ClojureScript

### DIFF
--- a/plugin/project.clj
+++ b/plugin/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-cljsbuild "0.3.0"
+(defproject lein-cljsbuild "0.4.0"
   :description "ClojureScript Autobuilder Plugin"
   :url "http://github.com/emezeske/lein-cljsbuild"
   :license
@@ -10,6 +10,6 @@
     :dev {
       :dependencies [
         [midje "1.4.0"]
-        [cljsbuild "0.3.0"]]
+        [cljsbuild "0.4.0"]]
       :plugins [[lein-midje "2.0.4"]]}}
   :eval-in-leiningen true)

--- a/plugin/src/leiningen/cljsbuild/subproject.clj
+++ b/plugin/src/leiningen/cljsbuild/subproject.clj
@@ -3,7 +3,7 @@
   (:require
     [clojure.string :as string]))
 
-(def cljsbuild-version "0.3.0")
+(def cljsbuild-version "0.4.0")
 (def required-clojure-version "1.4.0")
 
 (def cljsbuild-dependencies

--- a/support/project.clj
+++ b/support/project.clj
@@ -1,4 +1,4 @@
-(defproject cljsbuild "0.3.0"
+(defproject cljsbuild "0.4.0"
   :description "ClojureScript Autobuilder"
   :url "http://github.com/emezeske/lein-cljsbuild"
   :license
@@ -6,11 +6,11 @@
      :url "http://www.eclipse.org/legal/epl-v10.html"
      :distribution :repo}
   :dependencies
-    [[org.clojure/clojure "1.4.0"]
-     [org.clojure/clojurescript "0.0-1552"
+    [[org.clojure/clojure "1.5.1"]
+     [org.clojure/clojurescript "0.0-1803"
        :exclusions [org.apache.ant/ant]]
      ; Ugly workaround for http://dev.clojure.org/jira/browse/CLJS-418
-     [org.clojure/google-closure-library-third-party "0.0-2029"]
+     [org.clojure/google-closure-library-third-party "0.0-2029-2"]
      [fs "1.1.2"]
      [clj-stacktrace "0.2.5"]]
   :profiles {


### PR DESCRIPTION
This patch simply updates the version of ClojureScript that's included and increments the minor version number.  
