### PR TITLE
Update clojurescript to version 0.0-1806

### DIFF
--- a/support/project.clj
+++ b/support/project.clj
@@ -7,7 +7,7 @@
      :distribution :repo}
   :dependencies
     [[org.clojure/clojure "1.5.1"]
-     [org.clojure/clojurescript "0.0-1803"
+     [org.clojure/clojurescript "0.0-1806"
        :exclusions [org.apache.ant/ant]]
      [fs "1.1.2"]
      [clj-stacktrace "0.2.5"]]


### PR DESCRIPTION
There seems to have been a quick bugfix release after 0.0-1803. This patch bumps the Clojurescript version to latest.
