### PR TITLE
Update sample.project.clj to show the behaviour of the foreign-libs under redirects

### DIFF
--- a/sample.project.clj
+++ b/sample.project.clj
@@ -115,7 +115,7 @@
           ; watched and a rebuild will occur if they are modified.
           ; Defaults to the empty vector [].
           :libs ["closure/library/third_party/closure"]
-          ; Adds dependencies on foreign libraries.
+          ; Adds dependencies on foreign libraries. Be sure that the url returns a HTTP Code 200
           ; Defaults to the empty vector [].
           :foreign-libs [{:file "http://example.com/remote.js"
                            :provides  ["my.example"]}]}}}})


### PR DESCRIPTION
The :foreign-libs options only downloads the file from the url if it returns a 200.
If it returns a redirect (301, 302) the download is skipped and no message is given.

This is to document the behaviour to other people not get frustrated.
