### PR TITLE
made advanced example test build compile the src-cljs path

### DIFF
--- a/example-projects/advanced/project.clj
+++ b/example-projects/advanced/project.clj
@@ -67,7 +67,7 @@
       ; be run via PhantomJS.  See the phantom/unit-test.js file
       ; for details on how it's run.
       :test
-      {:source-paths ["test-cljs"]
+      {:source-paths ["src-cljs" "test-cljs"]
        :compiler {:output-to "resources/private/js/unit-test.js"
                   :optimizations :whitespace
                   :pretty-print true}}}}


### PR DESCRIPTION
This should make it a little more clear for beginners. They can just run `lein cljsbuild test` instead of `lein do cljsbuild once, cljsbuild test`.

Clarifies Issue #140.
