### PR TITLE
Handle case-sensitivity, fixes #240

### DIFF
--- a/support/src/cljsbuild/compiler.clj
+++ b/support/src/cljsbuild/compiler.clj
@@ -84,8 +84,8 @@
       path)))
 
 (defn- relativize [parent path]
-  (let [path (fs/absolute-path path)
-        parent (fs/absolute-path parent)]
+  (let [path (.getCanonicalPath (fs/file path))
+        parent (.getCanonicalPath (fs/file parent))]
     (if (.startsWith path parent)
       (subs path (count parent))
       path)))


### PR DESCRIPTION
The result of fs/absolute-path might differ in case. Result of
getCanonicalPath is defined to "be both absolute and unique" [1]. As
noted by Chas, in #240, this probably is an incremental solution only.

[1] http://docs.oracle.com/javase/7/docs/api/java/io/File.html#getCanonicalPath()
