### PR TITLE
Touch output file after build to support manic file saving.

### DIFF
--- a/support/src/cljsbuild/compiler.clj
+++ b/support/src/cljsbuild/compiler.clj
@@ -56,6 +56,7 @@
       (try
         (binding [*assert* assert?]
           (build (SourcePaths. cljs-paths) compiler-options))
+        (fs/touch output-file (/ started-at 1000000))
         (notify-cljs
           notify-command
           (str "Successfully compiled \"" output-file "\" in " (elapsed started-at) ".") green)


### PR DESCRIPTION
A save during a compilation should trigger a recompilation. This patch will touch the output file to change its mod time to the time the compilation _started_.

This is much better, but there is still a race condition. A perfect solution would touch the output file to the maximum of the times of the files that triggered the recompile. This change would have been very invasive to the API and I believe this is a sufficient solution.

Fixes https://github.com/emezeske/lein-cljsbuild/issues/276
