### PR TITLE
Add :preamble

### DIFF
--- a/sample.project.clj
+++ b/sample.project.clj
@@ -132,4 +132,7 @@
           ; Adds dependencies on foreign libraries. Be sure that the url returns a HTTP Code 200
           ; Defaults to the empty vector [].
           :foreign-libs [{:file "http://example.com/remote.js"
-                           :provides  ["my.example"]}]}}}})
+                           :provides  ["my.example"]}]
+          ; Prepends the contents of the given files to each output file.
+          ; Defaults to the empty vector [].
+          :preamble ["license.js"]}}}})


### PR DESCRIPTION
Since https://github.com/clojure/clojurescript/commit/136bf46c656265a93dd15c40925f11edb34bd127 the Clojurescript compiler supports :preamble
