### PR TITLE
Warn instead of crash when ClojureScript dependency is a SNAPSHOT version

### DIFF
--- a/plugin/src/leiningen/cljsbuild/subproject.clj
+++ b/plugin/src/leiningen/cljsbuild/subproject.clj
@@ -67,16 +67,19 @@
                    "-" (str (or (second acceptable-cljs-range) "*") ".")]]
     (check-clojure-version project)
     (if desired-cljs-version
-      (when-not (cljs-compat/version-in-range? (first desired-cljs-version) acceptable-cljs-range)
-        (print "\033[31m")
-        (apply println (concat cljs-version-message
-                               ["You are attempting to use ClojureScript"
-                                (str (first desired-cljs-version) ",")
-                                "which is not within this range. You can either change your"
-                                "ClojureScript dependency to fit in the range, or change your"
-                                "lein-cljsbuild plugin dependency to one that supports"
-                                "ClojureScript" (str (first desired-cljs-version) ".")]))
-        (lmain/abort "\033[0m"))
+      (if-not (re-matches #".+-SNAPSHOT" (first desired-cljs-version))
+        (when-not (cljs-compat/version-in-range? (first desired-cljs-version) acceptable-cljs-range)
+          (print "\033[31m")
+          (apply println (concat cljs-version-message
+                                 ["You are attempting to use ClojureScript"
+                                  (str (first desired-cljs-version) ",")
+                                  "which is not within this range. You can either change your"
+                                  "ClojureScript dependency to fit in the range, or change your"
+                                  "lein-cljsbuild plugin dependency to one that supports"
+                                  "ClojureScript" (str (first desired-cljs-version) ".")]))
+          (lmain/abort "\033[0m"))
+        (println "\033[33mWARNING: SNAPSHOT version of ClojureScript may be incompatible"
+                 "with lein-cljsbuild.\033[0m"))
       (do
         (println "\033[33mWARNING: It appears your project does not contain a ClojureScript"
                  "dependency. One will be provided for you by lein-cljsbuild, but it"


### PR DESCRIPTION
This fixes the crash (traceback below) that occurs when you have an `[org.clojure/clojurescript "0.0-SNAPSHOT"]` dependency.

I didn't opt to treat SNAPSHOT as a "99999" version because a SNAPSHOT can be too old, too new, or just plain broken.  Hopefully the people depending on a SNAPSHOT version of ClojureScript know what they're doing and won't be surprised if lein-cljsbuild is not compatible with it.  The warning should remind them, anyway.

```
java.lang.NumberFormatException: For input string: "SNAPSHOT"
 at java.lang.NumberFormatException.forInputString (NumberFormatException.java:65)
    java.lang.Long.parseLong (Long.java:589)
    java.lang.Long.parseLong (Long.java:631)
    cljsbuild.compat$parse_version.invoke (compat.clj:17)
    clojure.core$map$fn__4245.invoke (core.clj:2557)
    clojure.lang.LazySeq.sval (LazySeq.java:40)
    clojure.lang.LazySeq.seq (LazySeq.java:49)
    clojure.lang.RT.seq (RT.java:484)
    clojure.lang.RT.nthFrom (RT.java:848)
    clojure.lang.RT.nth (RT.java:807)
    cljsbuild.compat$version_in_range_QMARK_.invoke (compat.clj:22)
    leiningen.cljsbuild.subproject$merge_dependencies.invoke (subproject.clj:70)
    leiningen.cljsbuild.subproject$make_subproject.invoke (subproject.clj:101)
    leiningen.figwheel$run_local_project.invoke (figwheel.clj:25)
    leiningen.figwheel$run_compiler.invoke (figwheel.clj:58)
    leiningen.figwheel$figwheel.doInvoke (figwheel.clj:143)
    clojure.lang.RestFn.invoke (RestFn.java:410)
    clojure.lang.Var.invoke (Var.java:379)
    clojure.lang.AFn.applyToHelper (AFn.java:154)
    clojure.lang.Var.applyTo (Var.java:700)
    clojure.core$apply.invoke (core.clj:626)
    leiningen.core.main$resolve_task$fn__1406.doInvoke (main.clj:221)
    clojure.lang.RestFn.invoke (RestFn.java:410)
    clojure.lang.AFn.applyToHelper (AFn.java:154)
    clojure.lang.RestFn.applyTo (RestFn.java:132)
    clojure.lang.AFunction$1.doInvoke (AFunction.java:29)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.core$apply.invoke (core.clj:626)
    leiningen.core.main$apply_task.invoke (main.clj:262)
    leiningen.core.main$resolve_and_apply.invoke (main.clj:266)
    leiningen.core.main$_main$fn__1469.invoke (main.clj:336)
    leiningen.core.main$_main.doInvoke (main.clj:323)
    clojure.lang.RestFn.invoke (RestFn.java:408)
    clojure.lang.Var.invoke (Var.java:379)
    clojure.lang.AFn.applyToHelper (AFn.java:154)
    clojure.lang.Var.applyTo (Var.java:700)
    clojure.core$apply.invoke (core.clj:624)
    clojure.main$main_opt.invoke (main.clj:315)
    clojure.main$main.doInvoke (main.clj:420)
    clojure.lang.RestFn.invoke (RestFn.java:436)
    clojure.lang.Var.invoke (Var.java:388)
    clojure.lang.AFn.applyToHelper (AFn.java:160)
    clojure.lang.Var.applyTo (Var.java:700)
    clojure.main.main (main.java:37)
```
