### PR TITLE
Allow UI to parse build options (adding "list" subtask)

### DIFF
--- a/plugin/src/leiningen/cljsbuild.clj
+++ b/plugin/src/leiningen/cljsbuild.clj
@@ -216,7 +216,7 @@
         "auto" (auto project options args)
         "clean" (clean project options)
         "test" (test project options args)
-        "list" (println options)
+        "list" (println (pr-str options))
         "repl-listen" (repl-listen project options)
         "repl-launch" (repl-launch project options args)
         "repl-rhino" (repl-rhino project options)


### PR DESCRIPTION
Hi, we're building a UI tool on top of cljsbuild to help with clojurescript adoption, and we would like to be able to access the normalized build options for displaying and controlling from the UI.

```
$ lein cljsbuild list
{:builds ({:id server, :source-paths [src/server], :jar false, :notify-command nil, :incremental true, :assert true, :compiler {:pretty-print true, :output-dir /Users/swilliam/code/t3tr0s/target/cljsbuild-compiler-0, :target :nodejs, :output-to server.js, :libs [closure-js/libs], :language-out :ecmascript5, :warnings true, :language-in :ecmascript5, :externs [closure-js/externs], :optimizations :simple}} {:id client-adv, :source-paths [src/client], :jar false, :notify-command nil, :incremental true, :assert true, :compiler {:output-dir /Users/swilliam/code/t3tr0s/target/cljsbuild-compiler-1, :output-to public/js/client.min.js, :optimizations :advanced, :warnings true, :externs [externs/jquery-1.9.js externs/socket.io.js closure-js/externs], :libs [closure-js/libs], :pretty-print false}} {:id client, :source-paths [src/client], :jar false, :notify-command nil, :incremental true, :assert true, :compiler {:output-dir public/out, :output-to public/js/client.js, :optimizations :whitespace, :warnings true, :externs [closure-js/externs], :libs [closure-js/libs], :pretty-print true}}), :repl-launch-commands {}, :repl-listen-port 9000, :test-commands {}, :crossover-path /Users/swilliam/code/t3tr0s/target/cljsbuild-crossover, :crossover-jar false, :crossovers []}
```

Having a small "list" subtask would open the door for something like [cljsbuild-ui](https://github.com/oakmac/cljsbuild-ui) below:

![screenshot](https://raw.githubusercontent.com/oakmac/cljsbuild-ui/master/screenshots/2014-10-17-preview.png)
