### PR TITLE
Fix links to moved ring repo

### DIFF
--- a/example-projects/advanced/README.md
+++ b/example-projects/advanced/README.md
@@ -103,6 +103,6 @@ running in the background:
     $ lein trampoline cljsbuild repl-launch phantom-naked
 
 [1]: https://github.com/emezeske/lein-cljsbuild
-[2]: https://github.com/mmcgrana/ring
+[2]: https://github.com/ring-clojure/ring
 [3]: https://github.com/weavejester/compojure
 [4]: https://github.com/technomancy/leiningen

--- a/example-projects/simple/README.md
+++ b/example-projects/simple/README.md
@@ -18,6 +18,6 @@ Set up and start the server like this:
 Now, point your web browser at `http://localhost:3000`, and see the web app in action!
 
 [1]: https://github.com/emezeske/lein-cljsbuild
-[2]: https://github.com/mmcgrana/ring
+[2]: https://github.com/ring-clojure/ring
 [3]: https://github.com/weavejester/compojure
 [4]: https://github.com/technomancy/leiningen


### PR DESCRIPTION
The ring repo has been moved form  [mmcgrana/ring](https://github.com/mmcgrana/ring)  to [ring-clojure/ring](https://github.com/ring-clojure/ring)
