### PR TITLE
Allow compat to work with snapshots

### DIFF
--- a/cljs-compat/src/cljsbuild/compat.clj
+++ b/cljs-compat/src/cljsbuild/compat.clj
@@ -20,8 +20,9 @@
     (throw (IllegalArgumentException. (str "Unparseable version: " version-string)))))
 
 (defn version-in-range?
-   [version [low high]]
-   (let [[version low high] (map parse-version [version low (or high "9.9.9-99999")])]
-     (and (<= (compare low version) 0)
-          (<= 0 (compare high version)))))
-
+  [version [low high]]
+  (if (.contains version "SNAPSHOT")
+    true
+    (let [[version low high] (map parse-version [version low (or high "9.9.9-99999")])]
+      (and (<= (compare low version) 0)
+           (<= 0 (compare high version))))))


### PR DESCRIPTION
Always return true if the user has a SNAPSHOT version of ClojureScript. Currently the code throws an ugly NumberFormatException.
