### PR TITLE
fixing :libs filtering bug

### DIFF
--- a/support/src/cljsbuild/compiler.clj
+++ b/support/src/cljsbuild/compiler.clj
@@ -129,14 +129,16 @@
             (for [cljs-path cljs-paths]
               [cljs-path (util/find-files cljs-path #{"clj"})]))
         cljs-files (mapcat #(util/find-files % #{"cljs"}) (conj cljs-paths crossover-path))
-        js-files (->> lib-paths
-                      (mapcat #(util/find-files % #{"js"}))
+        js-files (let [output-dir-str
+                       (.getAbsolutePath (io/file (:output-dir compiler-options)))]
+                   (->> lib-paths
+                        (mapcat #(util/find-files % #{"js"}))
                       ; Don't include js files in output-dir or our output file itself,
                       ; both possible if :libs is set to [""] (a cljs compiler workaround to
                       ; load all libraries without enumerating them, see
                       ; http://dev.clojure.org/jira/browse/CLJS-526)
-                      (remove #(.startsWith ^String % (:output-dir compiler-options)))
-                      (remove #(.endsWith ^String % (:output-to compiler-options))))
+                      (remove #(.startsWith ^String % output-dir-str))
+                      (remove #(.endsWith ^String % (:output-to compiler-options)))))
         macro-mtimes (get-mtimes macro-files)
         clj-mtimes (get-mtimes (mapcat second clj-files-in-cljs-paths))
         cljs-mtimes (get-mtimes cljs-files)


### PR DESCRIPTION
I just noticed this when I was going through the code.

The filtering of js-file build dependencies to keep built files out of
the dependancies wasn’t working. This patch fixes it.

To cause the bug just set :libs to your output-dir and look at the
dependency mtimes list. You will see that it contains all the compiled
js files.

This patch fixes that.
