### PR TITLE
Optimizing environment reload

### DIFF
--- a/support/test/cljsbuild/test/compiler.clj
+++ b/support/test/cljsbuild/test/compiler.clj
@@ -62,5 +62,8 @@
     (fs/mod-time crossover-file) => mtime :times 1
     (fs/mod-time crossover-macro-absolute) => mtime :times 1
     (fs/mkdirs anything) => nil
-    (reload-clojure [crossover-macro-classpath] compiler-options-with-defaults notify-command) => nil :times 1
+    (reload-clojure ["src-cljs-a/file-a.cljs"
+                     "src-cljs-b/file-b.cljs"
+                     "crossovers/file-c.cljs"]
+                    [crossover-macro-classpath] compiler-options-with-defaults notify-command) => nil :times 1
     (cljs/build cljs-sourcepaths compiler-options-with-defaults) => nil :times 1))


### PR DESCRIPTION
Currently working on clj files in auto mode is difficult as it causes a
complete rebuild from the ground up external dependancies do not need
to be recompiled.

This commit demonstrates a reload procedure that is equivalent to the
current one but is a lot faster because because all compiled
dependancies are not deleted.

The method employed here touches the compiled target files for all cljs
sources (including crossover sources) with an old modification time.
This forces the compiler to rebuild all local class source files.

External dependancies cannot rely on the current project so there is no
need for them to be recompiled.

This patch is still a blunt way to handle this but it is tremendously
more efficient for the most common cases.
