### PR TITLE
fix reloading of clj files in cljs dirs

### DIFF
--- a/support/project.clj
+++ b/support/project.clj
@@ -7,7 +7,7 @@
      :distribution :repo}
   :dependencies
     [[org.clojure/clojure "1.5.1"]
-     [org.clojure/clojurescript "0.0-2197"
+     [org.clojure/clojurescript "0.0-2411"
        :exclusions [org.apache.ant/ant]]
      [fs "1.1.2"]
      [clj-stacktrace "0.2.5"]]

--- a/support/src/cljsbuild/compiler.clj
+++ b/support/src/cljsbuild/compiler.clj
@@ -99,13 +99,7 @@
   ; not affect any cljs file mtimes, we have to clear the cache here to force everything
   ; to be rebuilt.
   (fs/delete-dir (:output-dir compiler-options))
-  (doseq [path paths
-          ; only Clojure files that define macros can possibly affect
-          ; ClojureScript compilation; those that don't might define the "same"
-          ; namespace as a same-named ClojureScript file, and thus interfere
-          ; with cljsc's usage of Clojure namespaces during compilation. gh-210
-          :when (-> path (string/replace #"^/" "") io/resource
-                    ^String slurp (.contains "defmacro"))]
+  (doseq [path paths]
     (try
       (load (drop-extension path))
       (catch Throwable e


### PR DESCRIPTION
cljsbuild “auto” produces different results than “once” if a clj file that is a dependency of a clj based macro file changes.  This is because non-macro clj files are not reloaded on change.

This issue https://github.com/emezeske/lein-cljsbuild/issues/210 is why a guard was put in to prevent the loading of non macro clj files.  This issue appears to have been resolved as of clojurescript 2202.

And so I removed the guard that only allows .clj files that contain macros to be reloaded.  I have tested this and it works pretty darn good :)
