### PR TITLE
Fix broken links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,16 @@ to install and allows you to configure the ClojureScript compiler from within yo
 
 Beyond basic compiler support, lein-cljsbuild can optionally help with a few other things:
 
-* [Launching REPLs for interactive development] (https://github.com/emezeske/lein-cljsbuild/blob/1.0.4-SNAPSHOT/doc/REPL.md)
-* [Launching ClojureScript tests] (https://github.com/emezeske/lein-cljsbuild/blob/1.0.4-SNAPSHOT/doc/TESTING.md)
+* [Launching REPLs for interactive development] (https://github.com/emezeske/lein-cljsbuild/blob/master/doc/REPL.md)
+* [Launching ClojureScript tests] (https://github.com/emezeske/lein-cljsbuild/blob/master/doc/TESTING.md)
 * Sharing code between Clojure and ClojureScript: use
   [cljx](http://github.com/lynaghk/cljx) to target both Clojure and
   ClojureScript from the same codebase. ([cljsbuild
-  crossovers](https://github.com/emezeske/lein-cljsbuild/blob/1.0.4-SNAPSHOT/doc/CROSSOVERS.md)
+  crossovers](https://github.com/emezeske/lein-cljsbuild/blob/master/doc/CROSSOVERS.md)
   are _deprecated_, and will be removed in v2.x [coming later in 2014].)
 
 The latest version of lein-cljsbuild is `1.0.4-SNAPSHOT`.
-[See the release notes here.](https://github.com/emezeske/lein-cljsbuild/blob/1.0.4-SNAPSHOT/doc/RELEASE-NOTES.md)
+[See the release notes here.](https://github.com/emezeske/lein-cljsbuild/blob/master/doc/RELEASE-NOTES.md)
 
 ## Requirements
 
@@ -49,15 +49,15 @@ version of lein-cljsbuild currently requires a minimum of ClojureScript
 ## Just Give Me a Damned Example Already!
 
 See the
-[example-projects] (https://github.com/emezeske/lein-cljsbuild/blob/1.0.4-SNAPSHOT/example-projects)
+[example-projects] (https://github.com/emezeske/lein-cljsbuild/blob/master/example-projects)
 directory for a couple of simple examples of how to use lein-cljsbuild.  The
-[simple project] (https://github.com/emezeske/lein-cljsbuild/blob/1.0.4-SNAPSHOT/example-projects/simple)
+[simple project] (https://github.com/emezeske/lein-cljsbuild/blob/master/example-projects/simple)
 shows a dead-simple "compile only" configuration, which is a good place to start.  The
-[advanced project] (https://github.com/emezeske/lein-cljsbuild/blob/1.0.4-SNAPSHOT/example-projects/advanced)
+[advanced project] (https://github.com/emezeske/lein-cljsbuild/blob/master/example-projects/advanced)
 contains examples of how to use the extended features of the plugin.
 
 Also, see the
-[sample.project.clj] (https://github.com/emezeske/lein-cljsbuild/blob/1.0.4-SNAPSHOT/sample.project.clj)
+[sample.project.clj] (https://github.com/emezeske/lein-cljsbuild/blob/master/sample.project.clj)
 file for an exhaustive list of all options supported by lein-cljsbuild.
 
 ## Basic Configuration
@@ -81,7 +81,7 @@ of your `project.clj` file.  A simple project might look like this:
 ```
 
 For an exhaustive list of the configuration options supported by lein-cljsbuild, see the
-[sample.project.clj] (https://github.com/emezeske/lein-cljsbuild/blob/1.0.4-SNAPSHOT/sample.project.clj)
+[sample.project.clj] (https://github.com/emezeske/lein-cljsbuild/blob/master/sample.project.clj)
 file.
 
 ## Basic Usage
@@ -204,20 +204,20 @@ You can also build multiple configurations at once:
     $ lein cljsbuild auto main other
 
 See the
-[example-projects/advanced] (https://github.com/emezeske/lein-cljsbuild/blob/1.0.4-SNAPSHOT/example-projects/advanced)
+[example-projects/advanced] (https://github.com/emezeske/lein-cljsbuild/blob/master/example-projects/advanced)
 directory for a working example of a project that uses this feature.
 
 ## REPL Support
 
 Lein-cljsbuild has built-in support for launching ClojureScript REPLs in a variety
 of ways.  See the
-[REPL documentation] (https://github.com/emezeske/lein-cljsbuild/blob/1.0.4-SNAPSHOT/doc/REPL.md)
+[REPL documentation] (https://github.com/emezeske/lein-cljsbuild/blob/master/doc/REPL.md)
 for more details.
 
 ## Testing Support
 
 Lein-cljsbuild has built-in support for running external ClojureScript test processes.  See the
-[testing documentation] (https://github.com/emezeske/lein-cljsbuild/blob/1.0.4-SNAPSHOT/doc/TESTING.md)
+[testing documentation] (https://github.com/emezeske/lein-cljsbuild/blob/master/doc/TESTING.md)
 for more details.
 
 ## ClojureScript Version


### PR DESCRIPTION
All documentation points to 1.0.4-SNAPSHOT which returns 404. I've replaced it with what's on master since docs tend to be up-to-date there.
