### PR TITLE
Update README with new way of cleaning output

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ avoids the time-consuming JVM startup for each build:
 To delete all of the JavaScript and ClojureScript files that lein-cljsbuild
 automatically generated during compilation, run:
 
-    $ lein cljsbuild clean
+    $ lein clean
 
 If you've upgraded any libraries, you *probably* want to run `lein cljsbuild clean` afterward.
 


### PR DESCRIPTION
- `clean` substask was removed in rev 12e9955
