### PR TITLE
Pull in custom exception handlers (per-build)

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,27 @@ Lein-cljsbuild has built-in support for running external ClojureScript test proc
 [testing documentation] (https://github.com/emezeske/lein-cljsbuild/blob/1.0.4/doc/TESTING.md)
 for more details.
 
+## Extended Configuration
+
+### Custom warning handlers
+
+You can place custom warning handlers for the ClojureScript compiler under the `:warning-handlers` key. The value should be a vector of either 1.) fully-qualified symbols that resolve to your custom handler, or 2.) anonymous functions that will get eval'd at project build-time.
+
+```clj
+(defproject lein-cljsbuild-example "1.2.3"
+  :plugins [[lein-cljsbuild "1.0.4"]]
+  :cljsbuild {
+    :builds {:id           "example
+             :compiler     {}
+             :warning-handlers [my.ns/custom-warning-handler ;; Fully-qualified symbol
+                                ;; Custom function (to be evaluated at project build-time)
+                                (fn [warning-type env extra]
+                                  (when-let [s (cljs.analyzer/error-message warning-type extra)]
+                                    (binding [*out* *err*]
+                                      (cljs.analyzer/message env s))))]}})
+```
+
+
 ## ClojureScript Version
 
 After configuring lein-cljsbuild, `lein deps` will fetch a known-good version of the ClojureScript compiler.

--- a/plugin/src/leiningen/cljsbuild.clj
+++ b/plugin/src/leiningen/cljsbuild.clj
@@ -71,7 +71,7 @@
                       (doall
                        (for [[[build# compiler-env#] mtimes#] builds-mtimes#]
                        (cljs.analyzer/with-warning-handlers
-                         (if-let [handler# (:exception-handlers build#)]
+                         (if-let [handler# (:warning-handlers build#)]
                            (eval handler#)
                            cljs.analyzer/*cljs-warning-handlers*)
                          (binding [cljs.env/*compiler* compiler-env#]

--- a/plugin/src/leiningen/cljsbuild.clj
+++ b/plugin/src/leiningen/cljsbuild.clj
@@ -71,7 +71,7 @@
                       (doall
                        (for [[[build# compiler-env#] mtimes#] builds-mtimes#]
                        (cljs.analyzer/with-warning-handlers
-                         (if-let [handler# (:exception-handler build#)]
+                         (if-let [handler# (:exception-handlers build#)]
                            (eval handler#)
                            cljs.analyzer/*cljs-warning-handlers*)
                          (binding [cljs.env/*compiler* compiler-env#]

--- a/plugin/src/leiningen/cljsbuild.clj
+++ b/plugin/src/leiningen/cljsbuild.clj
@@ -70,6 +70,10 @@
                     new-dependency-mtimes#
                       (doall
                        (for [[[build# compiler-env#] mtimes#] builds-mtimes#]
+                       (cljs.analyzer/with-warning-handlers
+                         (if-let [handler# (:exception-handler build#)]
+                           (eval handler#)
+                           cljs.analyzer/*cljs-warning-handlers*)
                          (binding [cljs.env/*compiler* compiler-env#]
                            (cljsbuild.compiler/run-compiler
                             (:source-paths build#)
@@ -80,7 +84,7 @@
                             (:incremental build#)
                             (:assert build#)
                             mtimes#
-                            ~watch?))))]
+                            ~watch?)))))]
                  (when ~watch?
                    (Thread/sleep 100)
                    (recur new-dependency-mtimes#))))))))))


### PR DESCRIPTION
Exposes ClojureScript's custom warning handlers in a pretty raw form, so we can use them to store/alert/etc. 

Right now it's set per-build, but that could get pretty noisy (imagining what it would look like for all of Om's builds https://github.com/omcljs/om/blob/master/project.clj#L19)

Handlers are put under the `:exception-handlers` key (alongside the `:compiler` key), and should be a vector of functions. Each function takes the same arguments as `cljs.analyzer/default-warning-handler`, that is `[warning-type env extra]`. Line number, etc. can be pulled out of `env`

Here's an example build with two custom handlers:

```clj
                       {:id           "email"
                        :source-paths ["src"
                                       "examples/email/src"]
                        :compiler     {:preamble      ["react/react.min.js"]
                                       :output-to     "sul.email.dev.js"
                                       :output-dir    "email_out"
                                       :pretty-print  true
                                       :optimizations :none
                                       :source-map    true}
                        :exception-handlers [(fn [warning-type env extra]
                                               (when-let [s (cljs.analyzer/error-message warning-type extra)]
                                                 (binding [*out* *err*]
                                                   (println (pr-str warning-type))
                                                   (println (pr-str extra))
                                                   (println (cljs.analyzer/message env (str (clojure.string/reverse "SUPER CUSTOM WARNING: ") s))))))
                                             (fn [warning-type env extra]
                                               (import 'java.lang.Runtime)
                                               (when-let [s (cljs.analyzer/error-message warning-type extra)]
                                                 (let [title    "cljs-build"
                                                       subtitle (pr-str warning-type)
                                                       icon     "/Users/s/Downloads/clojure-icon.png"
                                                       file     cljs.analyzer/*cljs-file*
                                                       line     (:line env)
                                                       message  (str line ":" file " " (cljs.analyzer/message env s))
                                                       cmd      (str "terminal-notifier"
                                                                     " -title " title
                                                                     " -subtitle " subtitle
                                                                     " -activate com.googlecode.iterm2"
                                                                     " -appIcon " icon
                                                                     " -message "  (clojure.string/replace message " " "_"))]
                                                   (. (Runtime/getRuntime) exec cmd))))]}
```