### PR TITLE
Restore functionality of plugin tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ cljsbuild-*.*.*
 target
 plugin/target
 support/target
+support/output-to
 example-projects/*/*.jar
 example-projects/simple/resources
 example-projects/advanced/resources/public/js

--- a/bin/test-install.sh
+++ b/bin/test-install.sh
@@ -8,7 +8,7 @@ set -e
 
 projects="$@"
 [ -z "$projects" ] && projects='simple advanced'
-project_root=$(dirname $(realpath $0))/..
+project_root=$(dirname $0)/..
 pushd $project_root
 
 # needed to allow for post-release updates to cljs-compat

--- a/cljs-compat/project.clj
+++ b/cljs-compat/project.clj
@@ -6,6 +6,7 @@
   :description "Matrix of cljsbuild/ClojureScript compatibility"
   :url "http://github.com/emezeske/lein-cljsbuild"
   :license
-  {:name "Eclipse Public License - v 1.0"
-   :url "http://www.eclipse.org/legal/epl-v10.html"
-   :distribution :repo})
+    {:name "Eclipse Public License - v 1.0"
+     :url "http://www.eclipse.org/legal/epl-v10.html"
+     :distribution :repo}
+  :dependencies [[org.clojure/clojure "1.5.1"]])

--- a/plugin/project.clj
+++ b/plugin/project.clj
@@ -11,7 +11,7 @@
   :profiles {
     :dev {
       :dependencies [
-        [midje "1.5.1"]
+        [midje "1.6.3"]
         [cljsbuild "1.0.6"]]
-      :plugins [[lein-midje "2.0.4"]]}}
+      :plugins [[lein-midje "3.1.3"]]}}
   :eval-in-leiningen true)

--- a/plugin/test/leiningen/test/cljsbuild/config.clj
+++ b/plugin/test/leiningen/test/cljsbuild/config.clj
@@ -82,7 +82,8 @@
 
 (fact "missing compiler settings have defaults provided"
   (let [compiler (:compiler (get-build config-in))]
-    (doseq [compiler-option (keys compiler)]
+    (doseq [compiler-option (keys compiler)
+            :when (not= compiler-option :optimizations)]
       (let [defaulted (default-compiler-option config-in compiler compiler-option)]
         (get-compiler defaulted) => (contains {compiler-option anything})))))
 

--- a/plugin/test/leiningen/test/cljsbuild/subproject.clj
+++ b/plugin/test/leiningen/test/cljsbuild/subproject.clj
@@ -1,7 +1,14 @@
 (ns leiningen.test.cljsbuild.subproject
+  (:require
+    [leiningen.core.main :as lmain])
   (:use
     leiningen.cljsbuild.subproject
     midje.sweet))
+
+(background
+  (around
+    :facts (binding [lmain/*exit-process?* false]
+             ?form)))
 
 (fact
   (check-clojure-version {}) => nil
@@ -14,11 +21,11 @@
 (fact
   (let [original [clojure-dependency ['a "1"] ['b "2"]]
         merged (conj original ['cljsbuild cljsbuild-version])]
-    (merge-dependencies original) => (in-any-order merged))
+    (merge-dependencies original) => (just merged :in-any-order))
 
   (let [original [['a "1"] ['b "2"]]
         merged (concat original [clojure-dependency ['cljsbuild cljsbuild-version]])]
-    (merge-dependencies original) => (in-any-order merged)))
+    (merge-dependencies original) => (just merged :in-any-order)))
 
 (def lein-crossover ".crossovers")
 (def lein-build-source-paths ["src-cljs-a"])
@@ -50,4 +57,4 @@
     (:repositories subproject) => lein-repositories
     (:eval-in subproject) => lein-eval-in
     (:resource-paths subproject) => lein-resource-paths
-    (:dependencies subproject) => (in-any-order expected-dependencies)))
+    (:dependencies subproject) => (just expected-dependencies :in-any-order)))

--- a/support/project.clj
+++ b/support/project.clj
@@ -14,5 +14,5 @@
   :aot [cljsbuild.test]
   :profiles {
     :dev {
-      :dependencies [[midje "1.5.1"]]
-      :plugins [[lein-midje "2.0.4"]]}})
+      :dependencies [[midje "1.6.3"]]
+      :plugins [[lein-midje "3.1.3"]]}})


### PR DESCRIPTION
Hi,

I met some issues when tried to contribute to lein-cljsbuild. *lein test* for plugin project exited without summary page. After some digging I discovered that the reason was in calling System/exit during run-local-projects calls and calling leiningen.core.main/abort without setting *exit-process?*. In other words when you run tests then leiningen run several of them, meet test with System/exit call and exit without any error message. So I decided to restore tests functionality first to be sure that I will not break anything.

I prepared a fix for this issue. Furthermore I fixed one fact with incorrect condition, upgraded midje to the latest version and clojure dependency to cljs-compat project.

CR plz