### PR TITLE
Expose ClojureScript's custom warning handlers, per-build

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,27 @@ Lein-cljsbuild has built-in support for running external ClojureScript test proc
 [testing documentation] (https://github.com/emezeske/lein-cljsbuild/blob/1.0.4/doc/TESTING.md)
 for more details.
 
+## Extended Configuration
+
+### Custom warning handlers
+
+You can place custom warning handlers for the ClojureScript compiler under the `:warning-handlers` key. The value should be a vector of either 1.) fully-qualified symbols that resolve to your custom handler, or 2.) anonymous functions that will get eval'd at project build-time.
+
+```clj
+(defproject lein-cljsbuild-example "1.2.3"
+  :plugins [[lein-cljsbuild "1.0.4"]]
+  :cljsbuild {
+    :builds {:id           "example
+             :compiler     {}
+             :warning-handlers [my.ns/custom-warning-handler ;; Fully-qualified symbol
+                                ;; Custom function (to be evaluated at project build-time)
+                                (fn [warning-type env extra]
+                                  (when-let [s (cljs.analyzer/error-message warning-type extra)]
+                                    (binding [*out* *err*]
+                                      (cljs.analyzer/message env s))))]}})
+```
+
+
 ## ClojureScript Version
 
 After configuring lein-cljsbuild, `lein deps` will fetch a known-good version of the ClojureScript compiler.

--- a/plugin/src/leiningen/cljsbuild.clj
+++ b/plugin/src/leiningen/cljsbuild.clj
@@ -14,7 +14,8 @@
     [leiningen.test :as ltest]
     [leiningen.trampoline :as ltrampoline]
     [robert.hooke :as hooke]
-    [clojure.java.io :as io]))
+    [clojure.java.io :as io]
+    [clojure.string :as string]))
 
 (def ^:private repl-output-path "repl")
 
@@ -65,11 +66,32 @@
           (let [crossover-macro-paths# (cljsbuild.crossover/crossover-macro-paths '~crossovers)
                 builds# (for [opts# '~parsed-builds]
                           [opts# (cljs.env/default-compiler-env (:compiler opts#))])]
+            ;; Prep the environments
+            (doseq [[build# compiler-env#] builds#]
+              ;; Require any ns if necessary
+              (doseq [handler# (:warning-handlers build#)]
+                (when (symbol? handler#)
+                  (let [[n# sym#] (string/split (str handler#) #"/")]
+                    (assert (and n# sym#)
+                            (str "Symbols for :warning-handlers must be fully-qualified, " (pr-str handler#) " is missing namespace."))
+                    (when (and n# sym#)
+                      (require (symbol n#)))))))
             (loop [dependency-mtimes# (repeat (count builds#) {})]
               (let [builds-mtimes# (map vector builds# dependency-mtimes#)
                     new-dependency-mtimes#
                       (doall
                        (for [[[build# compiler-env#] mtimes#] builds-mtimes#]
+                       (cljs.analyzer/with-warning-handlers
+                         (if-let [handlers# (:warning-handlers build#)]
+                           ;; Prep the warning handlers via eval and
+                           ;; resolve if custom, otherwise default to
+                           ;; built-in warning handlers
+                           (mapv (fn [handler#]
+                                   ;; Resolve symbols to their fns
+                                   (if (symbol? handler#)
+                                     (resolve handler#)
+                                     handler#)) (eval handlers#))
+                           cljs.analyzer/*cljs-warning-handlers*)
                          (binding [cljs.env/*compiler* compiler-env#]
                            (cljsbuild.compiler/run-compiler
                             (:source-paths build#)
@@ -80,7 +102,7 @@
                             (:incremental build#)
                             (:assert build#)
                             mtimes#
-                            ~watch?))))]
+                            ~watch?)))))]
                  (when ~watch?
                    (Thread/sleep 100)
                    (recur new-dependency-mtimes#))))))))))


### PR DESCRIPTION
Warning handlers can be inline-functions, or fully-qualified symbols. Also updates the README with some usage info.