### PR TITLE
Track changes in checkouts folder in auto mode

### DIFF
--- a/plugin/src/leiningen/cljsbuild.clj
+++ b/plugin/src/leiningen/cljsbuild.clj
@@ -8,6 +8,7 @@
     [leiningen.cljsbuild.subproject :as subproject]
     [leiningen.compile :as lcompile]
     [leiningen.core.eval :as leval]
+    [leiningen.core.project :as lproject]
     [leiningen.core.main :as lmain]
     [leiningen.help :as lhelp]
     [leiningen.jar :as ljar]
@@ -36,6 +37,41 @@
            (System/exit 1))))
     requires))
 
+(defn- read-dependency-project [project-file]
+  (when (fs/exists? project-file)
+    (let [project (fs/absolute-path project-file)]
+      (try
+        (lproject/read project)
+        (catch Exception e
+          (throw (Exception. (format "Problem loading %s" project) e)))))))
+
+(defn- read-checkouts
+  [project]
+  (let [checkouts-dir (io/file (:root project) "checkouts")]
+    (for [dep (fs/list-dir checkouts-dir)
+          :let [project-file (io/file checkouts-dir dep "project.clj")
+                checkout-project (read-dependency-project project-file)]
+          :when checkout-project]
+      checkout-project)))
+
+(defn- walk-checkouts [root-project f]
+  (loop [[project & rest] (read-checkouts root-project)
+         walk-results []]
+    (if project
+      (recur (concat (read-checkouts project) rest)
+             (concat (f project) walk-results))
+      walk-results)))
+
+(defn- checkout-cljs-paths [project]
+  (walk-checkouts
+    project
+    (fn [checkout]
+      (let [{:keys [builds]} (config/extract-options checkout)
+            root (:root checkout)]
+        (for [build builds
+              path (:source-paths build)]
+          (fs/absolute-path (io/file root path)))))))
+
 (defn- run-compiler [project {:keys [crossover-path crossovers builds]} build-ids watch?]
   (doseq [build-id build-ids]
     (if (empty? (filter #(= (:id %) build-id) builds))
@@ -49,7 +85,8 @@
   (let [filtered-builds (if (empty? build-ids)
                           builds
                           (filter #(some #{(:id %)} build-ids) builds))
-        parsed-builds (map config/parse-notify-command filtered-builds)]
+        parsed-builds (map config/parse-notify-command filtered-builds)
+        checkout-cljs-paths (checkout-cljs-paths project)]
     (doseq [build parsed-builds]
       (config/warn-unsupported-warn-on-undeclared build)
       (config/warn-unsupported-notify-command build))
@@ -95,6 +132,7 @@
                          (binding [cljs.env/*compiler* compiler-env#]
                            (cljsbuild.compiler/run-compiler
                             (:source-paths build#)
+                            '~checkout-cljs-paths
                             ~crossover-path
                             crossover-macro-paths#
                             (:compiler build#)

--- a/plugin/test/leiningen/test/cljsbuild.clj
+++ b/plugin/test/leiningen/test/cljsbuild.clj
@@ -8,6 +8,9 @@
     [leiningen.cljsbuild.jar :as jar]
     [leiningen.cljsbuild.subproject :as subproject]
     [leiningen.core.eval :as leval]
+    [leiningen.core.project :as lproject]
+    [fs.core :as fs]
+    [clojure.java.io :as io]
     cljsbuild.crossover
     cljsbuild.util
     cljsbuild.compiler
@@ -55,8 +58,12 @@
 (def parsed-compiler
   (:compiler (first parsed-builds)))
 
+(def project-dir "/project")
+(def checkouts-dir (io/file project-dir "checkouts"))
+
 (def project
  {:dependencies [['org.clojure/clojure "1.5.1"]]
+  :root project-dir
   :cljsbuild
    {:repl-listen-port repl-listen-port
     :repl-launch-commands {repl-launch-command-id repl-launch-command}
@@ -97,6 +104,7 @@
     (with-mocks
       (apply cljsbuild project "once" extra-args)) => nil
     (provided
+      (fs/list-dir checkouts-dir) => nil, :times 1
       (cljsbuild.crossover/crossover-macro-paths
         crossovers) => crossover-macros :times 1
       (cljsbuild.crossover/copy-crossovers
@@ -104,6 +112,7 @@
         crossovers) => nil :times 1
       (cljsbuild.compiler/run-compiler
         source-paths
+        []
         crossover-path
         crossover-macros
         parsed-compiler
@@ -121,6 +130,7 @@
   (with-mocks
     (compile-hook hook-success project)) => nil
   (provided
+    (fs/list-dir checkouts-dir) => nil, :times 1
     (cljsbuild.crossover/crossover-macro-paths
       crossovers) => crossover-macros :times 1
     (cljsbuild.crossover/copy-crossovers
@@ -128,6 +138,7 @@
       crossovers) => nil :times 1
     (cljsbuild.compiler/run-compiler
       source-paths
+      []
       crossover-path
       crossover-macros
       parsed-compiler
@@ -137,16 +148,60 @@
       {}
       watch?) => nil :times 1))
 
+(fact "checkouts path are recognized and passed correctly"
+  (let [checkout-a-dir (io/file checkouts-dir "lib-a")
+        checkout-a-project (io/file checkout-a-dir "project.clj")
+        checkout-a-checkouts (io/file checkout-a-dir "checkouts")
+
+        checkout-b-dir (io/file checkouts-dir "lib-b")
+        checkout-b-project (io/file checkout-b-dir "project.clj")
+        checkout-b-checkouts (io/file checkout-b-dir "checkouts")]
+
+    (cljsbuild project "once") => nil
+    (provided
+      (fs/list-dir checkouts-dir) => ["lib-a" "lib-b"], :times 1
+      (fs/list-dir checkout-a-checkouts) => nil, :times 1
+      (fs/list-dir checkout-b-checkouts) => nil, :times 1
+      (fs/exists? checkout-a-project) => true, :times 1
+      (fs/exists? checkout-b-project) => true, :times 1
+
+      (lproject/read "/project/checkouts/lib-a/project.clj") =>
+        (assoc project :root (fs/absolute-path checkout-a-dir)), :times 1
+      (lproject/read "/project/checkouts/lib-b/project.clj") =>
+        (assoc project :root (fs/absolute-path checkout-b-dir)), :times 1
+
+      (cljsbuild.crossover/crossover-macro-paths
+        crossovers) => crossover-macros :times 1
+      (cljsbuild.crossover/copy-crossovers
+        crossover-path
+        crossovers) => nil :times 1
+      (cljsbuild.compiler/run-compiler
+        source-paths
+        ["/project/checkouts/lib-b/source-path-a"
+         "/project/checkouts/lib-b/source-path-b"
+         "/project/checkouts/lib-a/source-path-a"
+         "/project/checkouts/lib-a/source-path-b"]
+        crossover-path
+        crossover-macros
+        parsed-compiler
+        anything
+        incremental?
+        assert?
+        {}
+        watch?) => nil :times 1)))
+
 (fact "compile-hook does not call through to the compiler when task fails"
   (with-mocks
     (compile-hook hook-failure project)) => (throws Exception)
   (provided
+    (fs/list-dir checkouts-dir) => nil, :times 0
     (cljsbuild.crossover/crossover-macro-paths
       anything) => nil :times 0
     (cljsbuild.crossover/copy-crossovers
       anything
       anything) => nil :times 0
     (cljsbuild.compiler/run-compiler
+      anything
       anything
       anything
       anything
@@ -170,6 +225,7 @@
       (with-mocks
         (test-hook hook-failure project)) => (throws Exception)
       (against-background
+        (fs/list-dir checkouts-dir) => nil, :times 1
         (cljsbuild.crossover/crossover-macro-paths
           crossovers) => crossover-macros :times 0
         (cljsbuild.crossover/copy-crossovers
@@ -177,6 +233,7 @@
           crossovers) => nil :times 1
         (cljsbuild.compiler/run-compiler
           source-paths
+          []
           crossover-path
           crossover-macros
           parsed-compiler

--- a/support/src/cljsbuild/compiler.clj
+++ b/support/src/cljsbuild/compiler.clj
@@ -140,7 +140,7 @@
           (str "Reloading Clojure file \"" path "\" failed.") red)
         (pst+ e)))))
 
-(defn run-compiler [cljs-paths crossover-path crossover-macro-paths
+(defn run-compiler [cljs-paths checkout-paths crossover-path crossover-macro-paths
                     compiler-options notify-command incremental?
                     assert? last-dependency-mtimes watching?]
   (let [compiler-options (merge {:output-wrapper (= :advanced (:optimizations compiler-options))}
@@ -152,9 +152,9 @@
         macro-classpath-files (into {} (map vector macro-files (map :classpath crossover-macro-paths)))
         clj-files-in-cljs-paths
           (into {}
-            (for [cljs-path cljs-paths]
+            (for [cljs-path (concat cljs-paths checkout-paths)]
               [cljs-path (util/find-files cljs-path (conj additional-file-extensions "clj"))]))
-        cljs-files (mapcat #(util/find-files % (conj additional-file-extensions "cljs")) (conj cljs-paths crossover-path))
+        cljs-files (mapcat #(util/find-files % (conj additional-file-extensions "cljs")) (concat cljs-paths checkout-paths [crossover-path]))
         js-files (let [output-dir-str
                        (.getAbsolutePath (io/file (:output-dir compiler-options)))]
                    (->> lib-paths


### PR DESCRIPTION
Track changes in checkouts folder when cljsbuild auto mode is enabled (closes #319).
Straightforward way by passing additional parameter to run-compiler method.