### PR TITLE
Enhance pre-compilation message.

### DIFF
--- a/plugin/src/leiningen/cljsbuild.clj
+++ b/plugin/src/leiningen/cljsbuild.clj
@@ -40,7 +40,7 @@
   (doseq [build-id build-ids]
     (if (empty? (filter #(= (:id %) build-id) builds))
       (throw (Exception. (str "Unknown build identifier: " build-id)))))
-  (println "Compiling ClojureScript.")
+  (println (if watch? "Watching for changes before compiling ClojureScript..." "Compiling ClojureScript..."))
   ; If crossover-path does not exist before eval-in-project is called,
   ; the files it contains won't be classloadable, for some reason.
   (when (not-empty crossovers)


### PR DESCRIPTION
Pre-compilation message updated to accurately reflect the current state at the time the message is displayed. Previous behaviour gave the impression of having hung when auto compilation was run against an unchanged fileset.