### PR TITLE
Fixes #381 Honor :optimizations default :none

### DIFF
--- a/plugin/src/leiningen/cljsbuild/config.clj
+++ b/plugin/src/leiningen/cljsbuild/config.clj
@@ -23,7 +23,6 @@
 
 (defn- default-compiler-options [target-path]
   {:output-to (in-target-path target-path "main.js")
-   :optimizations :whitespace
    :warnings true
    :externs []
    :libs []


### PR DESCRIPTION
This change simply eliminates explicitly setting a value
for `:optimizations`, letting the compiler decide.