### PR TITLE
Support projects that only have cljc files

### DIFF
--- a/support/src/cljsbuild/compiler.clj
+++ b/support/src/cljsbuild/compiler.clj
@@ -146,8 +146,8 @@
         clj-files-in-cljs-paths
           (into {}
             (for [cljs-path cljs-paths]
-              [cljs-path (util/find-files cljs-path #{"clj"})]))
-        cljs-files (mapcat #(util/find-files % #{"cljs"}) (conj cljs-paths crossover-path))
+              [cljs-path (util/find-files cljs-path #{"cljc" "clj"})]))
+        cljs-files (mapcat #(util/find-files % #{"cljc" "cljs"}) (conj cljs-paths crossover-path))
         js-files (let [output-dir-str
                        (.getAbsolutePath (io/file (:output-dir compiler-options)))]
                    (->> lib-paths


### PR DESCRIPTION
This commit add support for projects that only contain cljc files. Those
projects were not build previously because `cljs-files` didn't contain
any files.