### PR TITLE
Fix bump versions script

### DIFF
--- a/bin/bump-versions.sh
+++ b/bin/bump-versions.sh
@@ -5,5 +5,5 @@ CURRENT_VERSION=$1
 NEXT_VERSION=$2
 
 for f in `find . -name project.clj` README.md `find doc -name '*.md' | grep -v RELEASE-NOTES.md`; do
-    sed -i s/$CURRENT_VERSION/$NEXT_VERSION/ $f
+    sed -i '' s/$CURRENT_VERSION/$NEXT_VERSION/ $f
 done


### PR DESCRIPTION
On OS X (at least), not passing any arguments to -i confuses sed and
causes errors when running in this script. Adding a zero length string
fixes this.