### PR TITLE
Extend LEIN_SILENT to cljsbuild (#417)

### DIFF
--- a/plugin/src/leiningen/cljsbuild.clj
+++ b/plugin/src/leiningen/cljsbuild.clj
@@ -83,7 +83,8 @@
   (doseq [build-id build-ids]
     (if (empty? (filter #(= (:id %) build-id) builds))
       (throw (Exception. (str "Unknown build identifier: " build-id)))))
-  (println (if watch? "Watching for changes before compiling ClojureScript..." "Compiling ClojureScript..."))
+  (lmain/info (if watch? "Watching for changes before compiling ClojureScript..."
+ "Compiling ClojureScript..."))
   ; If crossover-path does not exist before eval-in-project is called,
   ; the files it contains won't be classloadable, for some reason.
   (when (not-empty crossovers)

--- a/support/project.clj
+++ b/support/project.clj
@@ -2,17 +2,18 @@
   :description "ClojureScript Autobuilder"
   :url "http://github.com/emezeske/lein-cljsbuild"
   :license
-    {:name "Eclipse Public License - v 1.0"
-     :url "http://www.eclipse.org/legal/epl-v10.html"
-     :distribution :repo}
+  {:name "Eclipse Public License - v 1.0"
+   :url "http://www.eclipse.org/legal/epl-v10.html"
+   :distribution :repo}
   :dependencies
-    [[org.clojure/clojure "1.5.1"]
-     [org.clojure/clojurescript "0.0-2411"
-       :exclusions [org.apache.ant/ant]]
-     [fs "1.1.2"]
-     [clj-stacktrace "0.2.5"]]
+  [[org.clojure/clojure "1.5.1" :scope "provided"]
+   [leiningen-core "2.5.3"]
+   [org.clojure/clojurescript "0.0-2411"
+    :exclusions [org.apache.ant/ant]]
+   [fs "1.1.2"]
+   [clj-stacktrace "0.2.5"]]
   :aot [cljsbuild.test]
   :profiles {
-    :dev {
-      :dependencies [[midje "1.6.3"]]
-      :plugins [[lein-midje "3.1.3"]]}})
+             :dev {
+                   :dependencies [[midje "1.6.3"]]
+                   :plugins [[lein-midje "3.1.3"]]}})

--- a/support/src/cljsbuild/compiler.clj
+++ b/support/src/cljsbuild/compiler.clj
@@ -4,6 +4,7 @@
     [clj-stacktrace.repl :only [pst+]]
     [cljs.closure :only [build]])
   (:require
+    [leiningen.core.main :as lmain]
     [cljsbuild.util :as util]
     [cljs.analyzer :as analyzer]
     [cljs.closure :as closure]
@@ -34,7 +35,7 @@
       (catch Throwable e
         (println (red "Error running :notify-command:"))
         (pst+ e))))
-  (println (colorizer message)))
+  (lmain/info (colorizer message)))
 
 (defn ns-from-file [f]
   (try
@@ -56,7 +57,7 @@
         parents       (butlast relative-path)
         path          (apply str (interpose java.io.File/separator
                                             (cons target-dir parents)))]
-    (io/file (io/file path) 
+    (io/file (io/file path)
              (str (last relative-path) ".js"))))
 
 ;; Cannnot call build with ["src/cljs" "src/cljs-more"] cause build thinks a vector
@@ -69,7 +70,7 @@
 (defn- compile-cljs [cljs-paths compiler-options notify-command incremental? assert? watching?]
   (let [output-file (:output-to compiler-options)
         output-file-dir (fs/parent output-file)]
-    (println (str "Compiling \"" output-file "\" from " (pr-str cljs-paths) "..."))
+    (lmain/info (str "Compiling \"" output-file "\" from " (pr-str cljs-paths) "..."))
     (flush)
     (when (not incremental?)
       (fs/delete-dir (:output-dir compiler-options)))


### PR DESCRIPTION
Per the comment in #417 I have extended the LEIN_SILENT support to lein-cljsbuild.

Please note this introduces an additional, explicit dependency of **cljsbuild** on `[leiningen-core "2.5.3"]` which may be problematic (the proposed delta for **lein-cljsbuild** doesn't change the dependencies due to `:eval-in-leiningen true`).

NOTE: there remains this one non-Warning and non-Error **println** not converted (but perhaps should be?)
* https://github.com/emezeske/lein-cljsbuild/blob/master/support/src/cljsbuild/test.clj#L17

NOTE: There are whitespace changes in `support/project.clj` (due to *clojure-mode* and my Emacs `(add-hook 'before-save-hook 'delete-trailing-whitespace)`). The other significant change is change in scope of `org.clojure/clojure` to `"provided"`.