### PR TITLE
Use build api

### DIFF
--- a/example-projects/advanced/project.clj
+++ b/example-projects/advanced/project.clj
@@ -2,7 +2,7 @@
   :description "An advanced example of how to use lein-cljsbuild"
   :source-paths ["src-clj"]
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.clojure/clojurescript "0.0-2411"
+                 [org.clojure/clojurescript "0.0-3211"
                   :exclusions [org.apache.ant/ant]]
                  [compojure "1.1.6"]
                  [hiccup "1.0.4"]]

--- a/example-projects/none/project.clj
+++ b/example-projects/none/project.clj
@@ -3,7 +3,7 @@
   :url "http://example.com/FIXME"
 
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.clojure/clojurescript "0.0-2411"]]
+                 [org.clojure/clojurescript "0.0-3211"]]
 
   :plugins [[lein-cljsbuild "1.1.0"]]
 

--- a/example-projects/simple/project.clj
+++ b/example-projects/simple/project.clj
@@ -2,7 +2,7 @@
   :description "A simple example of how to use lein-cljsbuild"
   :source-paths ["src-clj"]
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.clojure/clojurescript "0.0-2411"
+                 [org.clojure/clojurescript "0.0-3211"
                   :exclusions [org.apache.ant/ant]]
                  [compojure "1.1.6"]
                  [hiccup "1.0.4"]]

--- a/sample.project.clj
+++ b/sample.project.clj
@@ -10,7 +10,7 @@
   :dependencies [[org.clojure/clojure "1.5.1"]
                  ; Your project should specify its own dependency on
                  ; ClojureScript
-                 [org.clojure/clojurescript "0.0-2197"
+                 [org.clojure/clojurescript "0.0-3211"
                   :exclusions [org.apache.ant/ant]]]
   ; Your project should plugin-depend on lein-cljsbuild, to ensure that
   ; the right version of the plugin is installed.

--- a/support/project.clj
+++ b/support/project.clj
@@ -7,7 +7,7 @@
      :distribution :repo}
   :dependencies
     [[org.clojure/clojure "1.5.1"]
-     [org.clojure/clojurescript "0.0-2411"
+     [org.clojure/clojurescript "0.0-3211"
        :exclusions [org.apache.ant/ant]]
      [fs "1.1.2"]
      [clj-stacktrace "0.2.5"]]

--- a/support/test/cljsbuild/test/compiler.clj
+++ b/support/test/cljsbuild/test/compiler.clj
@@ -3,9 +3,9 @@
     cljsbuild.compiler
     midje.sweet)
   (:require
-    [cljs.closure :as cljs]
     [cljsbuild.util :as util]
     [clojure.java.io :as io]
+    [cljs.build.api :as bapi]
     [fs.core :as fs]))
 
 (def cljs-path-a "src-cljs-a")
@@ -20,7 +20,6 @@
 (def cljs-checkout-file-b "checkouts/dep-b/cljs-src/file-b.cljs")
 (def checkout-paths [cljs-checkout-path-a cljs-checkout-path-b])
 
-(def cljs-sourcepaths (cljsbuild.compiler.SourcePaths. cljs-paths))
 (def crossover-path "crossovers")
 (def crossover-file (str crossover-path "/file-c.cljs"))
 (def crossover-macro-absolute "/a/b/crossovers/macros.clj")
@@ -84,4 +83,8 @@
                      cljs-checkout-file-b
                      crossover-file]
                     [crossover-macro-classpath] compiler-options-with-defaults notify-command) => nil :times 1
-    (cljs/build cljs-sourcepaths compiler-options-with-defaults) => nil :times 1))
+    ; bapi/inputs returns different instance each time and it doesn't provide equals method
+    (bapi/build
+      (as-checker #(and (instance? cljs.closure.Compilable %) (instance? cljs.closure.Inputs %)))
+      compiler-options-with-defaults)
+    => nil :times 1))


### PR DESCRIPTION
If/when http://dev.clojure.org/jira/browse/CLJS-1437 is merged current custom Compilable implementation will stop working. It's preferrable that `cljs.build.api/inputs` is used.

I believe `build` and `inputs` are available since cljs 0.0-3208: https://github.com/clojure/clojurescript/commit/5353489fe3beda9a6e9d044e89da3bd0d2accce7