### PR TITLE
Add mirrors project attribute to subproject map if it exists

### DIFF
--- a/plugin/src/leiningen/cljsbuild/subproject.clj
+++ b/plugin/src/leiningen/cljsbuild/subproject.clj
@@ -102,6 +102,7 @@
                             :jvm-opts
                             :local-repo
                             :repositories
+                            :mirrors
                             :resource-paths])
       {:local-repo-classpath true
        :dependencies (merge-dependencies (:dependencies project))


### PR DESCRIPTION
Similar to #290 and #291. In this case for mirrors. 

Currently the mirrors attribute is not being applied.

"Could not find artifact xxx in central (https://repo1.maven.org/maven2/)"
"Could not find artifact xxx in clojars (https://clojars.org/repo/)"