### PR TITLE
Avoid calls to cljs.build.api/src-file->target_file on deps.cljs

### DIFF
--- a/support/src/cljsbuild/compiler.clj
+++ b/support/src/cljsbuild/compiler.clj
@@ -133,7 +133,9 @@
           (into {}
             (for [cljs-path (concat cljs-paths checkout-paths)]
               [cljs-path (util/find-files cljs-path (conj additional-file-extensions "clj"))]))
-        cljs-files (mapcat #(util/find-files % (conj additional-file-extensions "cljs")) (concat cljs-paths checkout-paths [crossover-path]))
+        cljs-files (->> (concat cljs-paths checkout-paths [crossover-path])
+                     (mapcat #(util/find-files % (conj additional-file-extensions "cljs")))
+                     (remove #(contains? cljs.compiler/cljs-reserved-file-names (.getName (io/file %)))))
         js-files (let [output-dir-str
                        (.getAbsolutePath (io/file (:output-dir compiler-options)))]
                    (->> lib-paths


### PR DESCRIPTION
Right now compilation breaks on trying to extract deps.cljs namespace:

```
Caused by: java.lang.AssertionError: No ns form found in /Users/prokopov/work/cljs-raw/src/deps.cljs
	at cljs.analyzer$parse_ns$fn__2014.invoke(analyzer.cljc:2731)
	at cljs.analyzer$parse_ns.invoke(analyzer.cljc:2682)
	at cljs.analyzer$parse_ns.invoke(analyzer.cljc:2673)
	at cljs.closure$src_file__GT_target_file.invoke(closure.clj:1970)
	at cljs.build.api$src_file__GT_target_file.invoke(api.clj:93)
	at cljs.build.api$src_file__GT_target_file.invoke(api.clj:85)
	at cljsbuild.compiler$reload_clojure.invoke(compiler.clj:108)
	at cljsbuild.compiler$run_compiler.invoke(compiler.clj:160)
```