### PR TITLE
trampoline repl - fixes #204

### DIFF
--- a/plugin/project.clj
+++ b/plugin/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-cljsbuild "1.1.2"
+(defproject lein-cljsbuild "1.1.3-SNAPSHOT"
   :description "ClojureScript Autobuilder Plugin"
   :url "http://github.com/emezeske/lein-cljsbuild"
   :license

--- a/plugin/src/leiningen/cljsbuild.clj
+++ b/plugin/src/leiningen/cljsbuild.clj
@@ -34,7 +34,6 @@
   (leval/eval-in-project (subproject/make-subproject project crossover-path builds)
     `(try
        ~form
-       ~(exit)
        (catch cljsbuild.test.TestsFailedException e#
          ; Do not print stack trace on test failure
          ~(exit 1))

--- a/support/project.clj
+++ b/support/project.clj
@@ -1,4 +1,4 @@
-(defproject cljsbuild "1.1.2"
+(defproject cljsbuild "1.1.3-SNAPSHOT"
   :description "ClojureScript Autobuilder"
   :url "http://github.com/emezeske/lein-cljsbuild"
   :license


### PR DESCRIPTION
Remove the seemingly unnecessary call to `System.exit` after compilation.  This should fix the problem where trampoline commands were exiting before they started.