### PR TITLE
Fix bad ns form

### DIFF
--- a/support/test/cljsbuild/test/crossover.clj
+++ b/support/test/cljsbuild/test/crossover.clj
@@ -5,7 +5,7 @@
   (:require
     [clojure.java.io :as io]
     [fs.core :as fs])
-  (import java.net.URL))
+  (:import java.net.URL))
 
 (def crossover-path "/project/crossovers")
 (def crossovers '[a a.a a.b])


### PR DESCRIPTION
As of Clojure 1.9.0-alpha11, core specs will flag this as a compile error.