### PR TITLE
Add support for lein 2.7's `:managed-dependencies`

### DIFF
--- a/plugin/project.clj
+++ b/plugin/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-cljsbuild "1.1.4"
+(defproject lein-cljsbuild "1.1.5-SNAPSHOT"
   :description "ClojureScript Autobuilder Plugin"
   :url "http://github.com/emezeske/lein-cljsbuild"
   :license
@@ -6,10 +6,11 @@
      :url "http://www.eclipse.org/legal/epl-v10.html"
      :distribution :repo}
     :dependencies [[fs "1.1.2"]]
+  :min-lein-version "2.7.1"
   :profiles {
     :dev {
       :dependencies [
         [midje "1.6.3"]
-        [cljsbuild "1.1.4"]]
+        [cljsbuild "1.1.5-SNAPSHOT"]]
       :plugins [[lein-midje "3.1.3"]]}}
   :eval-in-leiningen true)

--- a/plugin/src/leiningen/cljsbuild/subproject.clj
+++ b/plugin/src/leiningen/cljsbuild/subproject.clj
@@ -3,7 +3,8 @@
   (:require
     [leiningen.core.main :as lmain]
     [clojure.java.io :refer (resource)]
-    [clojure.string :as string]))
+    [clojure.string :as string]
+    [leiningen.core.classpath :as classpath]))
 
 (def cljsbuild-version
   (let [[_ coords version]
@@ -71,13 +72,18 @@
          (map (fn [[k v]] (vec (cons k v)))))))
 
 (defn make-subproject [project crossover-path builds]
-  (with-meta
-    (merge
+  (let [deps (classpath/merge-versions-from-managed-coords
+              (get project :dependencies)
+              (get project :managed-dependencies))]
+    (with-meta
+     (merge
       project
       {:local-repo-classpath true
-       :dependencies (merge-dependencies (:dependencies project))
+       :dependencies (merge-dependencies deps)
        :source-paths (concat
-                       (:source-paths project)
-                       (mapcat :source-paths builds)
-                       [crossover-path])})
-    (meta project)))
+                      (:source-paths project)
+                      (mapcat :source-paths builds)
+                      [crossover-path])})
+     (meta project))))
+
+

--- a/support/project.clj
+++ b/support/project.clj
@@ -1,10 +1,11 @@
-(defproject cljsbuild "1.1.4"
+(defproject cljsbuild "1.1.5-SNAPSHOT"
   :description "ClojureScript Autobuilder"
   :url "http://github.com/emezeske/lein-cljsbuild"
   :license
     {:name "Eclipse Public License - v 1.0"
      :url "http://www.eclipse.org/legal/epl-v10.html"
      :distribution :repo}
+  :min-lein-version "2.7.1"
   :dependencies
     [[org.clojure/clojure "1.5.1"]
      [org.clojure/clojurescript "0.0-3211"


### PR DESCRIPTION
In lein 2.7.0, a new feature was added that allows you to specify dependency versions in a new `:managed-dependencies` vector, so that you can, e.g., inherit dependency versions from a parent project (via the lein-parent plugin, etc.).

For more info see [the Managed Dependencies docs in the lein repo](https://github.com/technomancy/leiningen/blob/master/doc/MANAGED_DEPS.md).

The current release of lein-cljsbuild won't work with projects that use this, because the version checks at startup assume that they will be able to find the dependency version numbers directly in the `:dependencies` vector.

This commit adds support for getting the dependency versions via the new mechanism.  It should be 100% backward compatible but it *does* introduce a min-lein-version of 2.7.

Opening this to solicit feedback.  If there's another way to structure this in order to deal with the min-lein-version issue, let me know and I'll be happy to re-work it.