### PR TITLE
Update sample.project.clj doc to reflect default :optimizations value

### DIFF
--- a/sample.project.clj
+++ b/sample.project.clj
@@ -98,7 +98,7 @@
           ; recommended setting for production, unless something prevents it (incompatible
           ; external library, bug, etc.).
           ; :none requires manual code loading and hence a separate HTML from the other options.
-          ; Defaults to :whitespace.
+          ; Defaults to :none.
           :optimizations :whitespace
           ; This flag will cause all (assert x) calls to be removed during compilation
           ; Useful for production. Default is always false even in advanced compilation.


### PR DESCRIPTION
The sample.project.clj file is used as an entry-point user reference to the compiler options, and so should be kept accurate.

I got stuck for a while trying to get ClojureScript testing with PhantomJS to work, [thinking](https://github.com/emezeske/lein-cljsbuild/commit/e6f8cfafdc51536bd1d57035809ae7825c5d5003) that `:optimizations` was already set to `:whitespace`.

Hope this saves people time. :)

Cheers