### PR TITLE
Fix #453: use ProcessBuilder for output redirect

### DIFF
--- a/support/test/cljsbuild/test/util.clj
+++ b/support/test/cljsbuild/test/util.clj
@@ -35,15 +35,6 @@
     (call-once-every) => nil :times 3
     (sleep 1000) => nil :times 3))
 
-(fact
-  (maybe-writer "filename" *out*) => :success
-  (provided
-    (fs/delete "filename") => nil :times 1
-    (io/writer "filename") => :success :times 1))
-
-(fact
-  (maybe-writer nil *out*) => *out*)
-
 ; TODO: It would be nice to test process-start, but it does a lot of Java
 ;       interop so I'm not sure how to go about that just yet.  Maybe if
 ;       it was switched to using "conch" instead of raw interop it would


### PR DESCRIPTION
Pull request #436 removes the call to exit that was added to address #171. This
caused a regression in testing and notify behaviour that was reported as #453,
where subprocesses would hang for 30 seconds after the subprocess completed.

This commit avoids the need for pump threads to copy data from subprocess
streams by using ProcessBuilder's existing Redirect functionality to either
write redirect stream output to files directly, or to inherit System.out and
System.err from the main process. This means that `lein test` etc now terminate
in a reasonable time again, and avoids the call to `exit` that was causing
problems for trampoline tasks.