### PR TITLE
Handle missing `:cljsbuild` configuration.

### DIFF
--- a/plugin/src/leiningen/cljsbuild.clj
+++ b/plugin/src/leiningen/cljsbuild.clj
@@ -72,11 +72,10 @@
   (walk-checkouts
     project
     (fn [checkout]
-      (let [{:keys [builds]} (config/extract-options checkout)
-            root (:root checkout)]
+      (if-let [{:keys [builds]} (config/extract-options checkout)]
         (for [build builds
               path (:source-paths build)]
-          (fs/absolute-path (io/file root path)))))))
+          (fs/absolute-path (io/file (:root checkout) path)))))))
 
 (defn- run-compiler [project {:keys [crossover-path crossovers builds]} build-ids watch?]
   (doseq [build-id build-ids]

--- a/plugin/src/leiningen/cljsbuild/config.clj
+++ b/plugin/src/leiningen/cljsbuild/config.clj
@@ -148,9 +148,9 @@
 (defn- normalize-options
   "Sets default options and accounts for backwards compatibility."
   [target-path options]
-  (let [options (convert-builds-map options)
-        compat (backwards-compat options)]
-    (when (not= options compat)
+  (let [convert (convert-builds-map options)
+        compat (backwards-compat convert)]
+    (when (and options (not= convert compat))
       (warn-deprecated compat))
     (->> compat
       (set-default-options target-path)
@@ -180,6 +180,6 @@
   "Given a project, returns a seq of cljsbuild option maps."
   [project]
   (when (nil? (:cljsbuild project))
-    (println "WARNING: no :cljsbuild entry found in project definition."))
+    (println "WARNING: no :cljsbuild entry found in" (:name project) "project definition."))
   (let [raw-options (:cljsbuild project)]
     (normalize-options (:target-path project) raw-options)))


### PR DESCRIPTION
When `:cljsbuild` entry is not found:
- Emit project name in warning.
- For checkouts, skip extraction of source paths (assume no cljs).
- Suppress deprecated warning (previous warning is sufficient).

Relates to #413 